### PR TITLE
Necro test

### DIFF
--- a/src/main/resources/data/mvp/loot_tables/blocks/vat_component_structural_t1.json
+++ b/src/main/resources/data/mvp/loot_tables/blocks/vat_component_structural_t1.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "pool1",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "mvp:vat_component_structural_t1"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/mvp/loot_tables/blocks/vat_component_structural_t1_transparent.json
+++ b/src/main/resources/data/mvp/loot_tables/blocks/vat_component_structural_t1_transparent.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "pool1",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "mvp:vat_component_structural_t1_transparent"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Created loot-table directory in data.mvp. Loot-tables are required for all blocks you wish to pick up after breaking. Loot tables have been created for T1 Vat Component Structural blocks as examples. 